### PR TITLE
Remove Keymaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     },
     "categories": [
         "Other",
-        "Snippets",
-        "Keymaps"
+        "Snippets"
     ],
     "activationEvents": [
         "*"


### PR DESCRIPTION
This extension looks great - however in a perfect world we would love to keep the Keymap category for helping users move from one editor/IDE to VS Code.  We have a tag of Keybinding that may be more appropriate?

As a result we would love to see if we can remove this from that cateogry, that is the goal of this PR.  Sorry for the confusion.

Sean
VS Code Team and @code